### PR TITLE
intern strings

### DIFF
--- a/revtok/subwords.py
+++ b/revtok/subwords.py
@@ -3,6 +3,7 @@ from .tokenizer import tokenize
 
 from collections import defaultdict, Counter
 from operator import attrgetter
+import sys
 
 from tqdm import tqdm
 
@@ -131,6 +132,7 @@ class SubwordSegmenter:
             else:
                 break
         ret = segments[len(utterance)]
+        ret = [sys.intern(seg) for seg in ret]
         self.cache[utterance] = ret
         return ret
 

--- a/revtok/tokenizer.py
+++ b/revtok/tokenizer.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import unicodedata
 
 
@@ -41,7 +42,7 @@ def tokenize(s, decap=False, split_punctuation=True):
         toks[-1] += HALF
     if decap:
         toks = list(map(decapitalize, toks))
-    return toks
+    return [sys.intern(tok) for tok in toks]
 
 
 def decapitalize(tok):


### PR DESCRIPTION
I wrongly thought Python interned all small strings by default, but it's only small _literal_ strings. Every tokenizer should intern its output—this reduces peak CPU memory usage of decaNLP by a factor of 100.